### PR TITLE
Fix for from_time_t bug

### DIFF
--- a/Core/Time.h
+++ b/Core/Time.h
@@ -36,8 +36,8 @@ operator<<(std::ostream& os,
         return os << "TimePoint::min()";
     if (timePoint == TimePoint::max())
         return os << "TimePoint::max()";
-
-    TimePoint unixEpoch = Clock::from_time_t(0);
+    
+    TimePoint unixEpoch = TimePoint();
     uint64_t microsSinceUnixEpoch =
         std::chrono::duration_cast<std::chrono::microseconds>(
                 timePoint - unixEpoch).count();


### PR DESCRIPTION
When trying to build from source, I was getting the following error:
./Core/Time.h:40:47: error: ‘from_time_t’ is not a member of ‘std::chrono::_V2::steady_clock’
     TimePoint unixEpoch = Clock::from_time_t(0);

Turns out that time_point has a standard constructor that begins at the epoch, so from_time_t isn't necessary, it is only defined for system_clock and not steady_clock
