### PR TITLE
Fix build: missing unistd.h include

### DIFF
--- a/Storage/SnapshotFile.cc
+++ b/Storage/SnapshotFile.cc
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "Core/Debug.h"
 #include "Core/StringUtil.h"


### PR DESCRIPTION
Got this error:
```
Compiling build/Storage/SnapshotFile.cc
build/Storage/SnapshotFile.cc: In member function ‘void LogCabin::Storage::SnapshotFile::Writer::seekToEnd()’:
build/Storage/SnapshotFile.cc:175:45: error: ‘lseek64’ was not declared in this scope
     off64_t r = lseek64(file.fd, 0, SEEK_END);
```

Building on debian jessie
```
lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 8.0 (jessie)
Release:	8.0
Codename:	jessie
```

