### PR TITLE
create & own the default logcabin data directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -344,7 +344,9 @@ pre_commands = [
 ]
 
 post_commands = [
-    'chown -R logcabin:logcabin /var/log/logcabin'
+    'chown -R logcabin:logcabin /var/log/logcabin',
+    'mkdir -p /var/lib/logcabin',
+    'chown logcabin:logcabin /var/lib/logcabin',
 ]
 
 # We probably don't want rpm to strip binaries.


### PR DESCRIPTION
I think this should be a 'do once on install' thing... if we put it in init, and the directory somehow temporarily disappears (if it's on a device that's unmounted), we really shouldn't create a new one.  Putting it in packaging roughly solves that.