### PR TITLE
expose getConfiguation timeout

### DIFF
--- a/Client/ClientImpl.h
+++ b/Client/ClientImpl.h
@@ -86,10 +86,11 @@ class ClientImpl {
      */
     virtual void initDerived();
 
-    std::pair<uint64_t, Configuration> getConfiguration();
+    GetConfigurationResult getConfiguration(TimePoint timeout);
     ConfigurationResult setConfiguration(
                             uint64_t oldId,
-                            const Configuration& newConfiguration);
+                            const Configuration& newConfiguration,
+                            TimePoint timeout);
 
     /// See Cluster::getServerInfo.
     Result getServerInfo(const std::string& host,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,10 +12,21 @@ Release Process
 
 See [RELEASE-PROCESS.md](RELEASE-PROCESS.md).
 
-Version 1.1.1-alpha.0 (In Development)
+Version 1.2.0-alpha.0 (In Development)
 ======================================
 
-Nothing noteworthy yet.
+New backwards-compatible changes:
+
+- Added new API getConfiguration2, which behaves as getConfiguration
+  but allows a timeout. The API returns a the configuration plus a
+  status code to allow for a TIMEOUT response.
+- Added companion getConfiguration2Ex that behaves as
+  getConfiguration2 but throws exceptions.
+- Added setConfiguration2 which behaves as setConfiguration but allows
+  a timeout.
+- Added companion setConfiguration2Ex that behaves as
+  setConfiguration2 throws exceptions.
+- See https://github.com/logcabin/logcabin/pull/184 for details
 
 
 Version 1.1.0 (2015-07-26)

--- a/SConstruct
+++ b/SConstruct
@@ -30,8 +30,8 @@ except AttributeError:
 # Access through env['VERSION'], env['RPM_VERSION'], and env['RPM_RELEASE'] to
 # allow users to override these. RPM versioning is explained here:
 # https://fedoraproject.org/wiki/Packaging:NamingGuidelines#NonNumericRelease
-_VERSION = '1.1.1-alpha.0'
-_RPM_VERSION = '1.1.1'
+_VERSION = '1.2.0-alpha.0'
+_RPM_VERSION = '1.2.0'
 _RPM_RELEASE = '0.1.alpha.0'
 
 opts = Variables('Local.sc')


### PR DESCRIPTION
In order to be able to properly collect the current state of logcabin, I need to be able to call getConfiguration on a logcabind instance, even if there is no cluster configured. Without the timeout, this will hang until TimePoint::max. There was a todo in the code to expose this timeout, so here it is. This commit changes the public interface to the client in include/LogCabin/Client.h, not sure if there are rules for that. If so, please let me know.