### PR TITLE
Skip systemctl redirect for redhat init script

### DIFF
--- a/scripts/logcabin-init-redhat
+++ b/scripts/logcabin-init-redhat
@@ -18,6 +18,8 @@
 # Short-Description: start and stop logcabin
 ### END INIT INFO
 
+SYSTEMCTL_SKIP_REDIRECT=1
+
 # Source function library.
 . /etc/rc.d/init.d/functions
 


### PR DESCRIPTION
This allows 'service logcabin start' to work properly on a systemd based distribution, like RHEL 7.x .