### PR TITLE
fix clusterUUID doc

### DIFF
--- a/sample.conf
+++ b/sample.conf
@@ -24,7 +24,7 @@
 # An opaque string used to prevent accidental communication across LogCabin
 # clusters. If set, this string will be checked when creating each
 # client-to-server and server-to-server session. If the recipient's has a cluster
-# UUID that does not match the UUID in the request, the connection will not be
+# UUID that does not match the UUID in the request, the connection will be
 # closed with an error.
 #
 # The default (empty string) allows communication with any client and server of


### PR DESCRIPTION
Reason and code suggest that connection *is* closed if a mismatching
clusterUUID is found on a request.