### PR TITLE
issue #200: update leader timeouts after disk write

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,6 +15,10 @@ See [RELEASE-PROCESS.md](RELEASE-PROCESS.md).
 Version 1.2.0-alpha.0 (In Development)
 ======================================
 
+Internal improvements:
+
+- #200: reset leader election timeout in follower after disk io completes
+
 New backwards-compatible changes:
 
 - Added new API getConfiguration2, which behaves as getConfiguration


### PR DESCRIPTION
in cases where disk writes can take longer than the leader election,
a follower can call for an election when one is not necessary. this
change resets the election related timers after all disk writes.

I don't fully understand what stepDown is doing or if we should call it again, but it does seem related to the other calls so I duplicated it, so I left in. In testing, this change is helping prevent the stated problem, which makes sense. I'll make whatever changes are requested.