### PR TITLE
issue-208: one liner fix to call doneWithRPC on RETRY

### DIFF
--- a/Client/ClientImpl.cc
+++ b/Client/ClientImpl.cc
@@ -394,6 +394,8 @@ ClientImpl::ExactlyOnceRPCHelper::keepAliveThreadMain()
                 case LeaderRPCBase::Call::Status::OK:
                     break;
                 case LeaderRPCBase::Call::Status::RETRY:
+                    doneWithRPC(trequest.exactly_once(),
+                                Core::HoldingMutex(lockGuard));
                     continue; // retry outer loop
                 case LeaderRPCBase::Call::Status::TIMEOUT:
                     PANIC("Unexpected timeout for keep-alive");


### PR DESCRIPTION
an RAII mechanism might be better here, but in the interest of time
and not letting perfect be the enemy of good, want to get this fix
in.