### PR TITLE
issue #205: do not start election after removing self from cluster

### DIFF
--- a/Server/RaftConsensus.cc
+++ b/Server/RaftConsensus.cc
@@ -2863,6 +2863,13 @@ RaftConsensus::startNewElection()
         return;
     }
 
+    if (commitIndex >= configuration->id &&
+        !configuration->hasVote(configuration->localServer)) {
+        // we are not in the latest configuration, do not start an election
+        setElectionTimer();
+        return;
+    }
+
     if (leaderId > 0) {
         NOTICE("Running for election in term %lu "
                "(haven't heard from leader %lu lately)",


### PR DESCRIPTION
a leader that has just left the cluster can win an
election. it will step down so this is just a temporary
situation but it can cause extended outages under
certain configuartions. with this change, a server
will detect that it has written itself out of the
cluster and will not run for election.

This is still in testing but putting in the pull request now for review and so I don't lose track of it.