### PR TITLE
uissue #213: fix deadlock in LogCabin::Core:Debug at flockfile

### DIFF
--- a/Core/Debug.cc
+++ b/Core/Debug.cc
@@ -420,6 +420,29 @@ log(LogLevel level,
 {
     va_list ap;
 
+    std::string message;
+    // this part is copied from Core::StringUtil::toString.
+    va_start(ap, format);
+    // We're not really sure how big of a buffer will be necessary.
+    // Try 1K, if not the return value will tell us how much is necessary.
+    size_t bufSize = 1024;
+    while (true) {
+        char buf[bufSize];
+        // vsnprintf trashes the va_list, so copy it first
+        va_list aq;
+        va_copy(aq, ap);
+        int r = vsnprintf(buf, bufSize, format, aq);
+        va_end(aq);
+        assert(r >= 0); // old glibc versions returned -1
+        size_t r2 = size_t(r);
+        if (r2 < bufSize) {
+            message = buf; // copy string
+            break;
+        }
+        bufSize = size_t(r2) + 1;
+    }
+    va_end(ap);
+
     if (logHandler) {
         DebugMessage d;
         d.filename = relativeFileName(fileName);
@@ -429,29 +452,7 @@ log(LogLevel level,
         d.logLevelString = logLevelToString(level);
         d.processName = processName;
         d.threadName = ThreadId::getName();
-
-        // this part is copied from Core::StringUtil::toString.
-        va_start(ap, format);
-        // We're not really sure how big of a buffer will be necessary.
-        // Try 1K, if not the return value will tell us how much is necessary.
-        size_t bufSize = 1024;
-        while (true) {
-            char buf[bufSize];
-            // vsnprintf trashes the va_list, so copy it first
-            va_list aq;
-            va_copy(aq, ap);
-            int r = vsnprintf(buf, bufSize, format, aq);
-            va_end(aq);
-            assert(r >= 0); // old glibc versions returned -1
-            size_t r2 = size_t(r);
-            if (r2 < bufSize) {
-                buf[r2 - 1] = '\0'; // strip off "\n" added by LOG macro
-                d.message = buf; // copy string
-                break;
-            }
-            bufSize = size_t(r2) + 1;
-        }
-        va_end(ap);
+        d.message = message;
         (logHandler)(d);
         return;
     }
@@ -481,22 +482,12 @@ log(LogLevel level,
         formattedSeconds[sizeof(formattedSeconds) - 1] = '\0';
     }
 
-    // This ensures that output on stderr won't be interspersed with other
-    // output. This normally happens automatically for a single call to
-    // fprintf, but must be explicit since we're using two calls here.
-    flockfile(stream);
-
-    fprintf(stream, "%s.%06lu %s:%d in %s() %s[%s:%s]: ",
+    fprintf(stream, "%s.%06lu %s:%d in %s() %s[%s:%s]: %s\n",
             formattedSeconds, now.tv_nsec / 1000,
             relativeFileName(fileName), lineNum, functionName,
             logLevelToString(level),
-            processName.c_str(), ThreadId::getName().c_str());
-
-    va_start(ap, format);
-    vfprintf(stream, format, ap);
-    va_end(ap);
-
-    funlockfile(stream);
+            processName.c_str(), ThreadId::getName().c_str(),
+            message.c_str());
 
     fflush(stream);
 }

--- a/Core/Debug.h
+++ b/Core/Debug.h
@@ -99,7 +99,7 @@ extern std::string processName;
     if (::LogCabin::Core::Debug::isLogging(level, __FILE__)) { \
         ::LogCabin::Core::Debug::log(level, \
             __FILE__, __LINE__, __FUNCTION__, \
-            format "\n", ##__VA_ARGS__); \
+            format, ##__VA_ARGS__); \
     } \
 } while (0)
 


### PR DESCRIPTION
in extensive testing with logrotate and verbose logging,
logcabin will occassionally hang at flockfile. the cause
is still a bit mysterious but there are multiple people
claiming there are issues with flockfile and signal
handlers. this commit pre-creates the log message so the
internal flockfile call can be used. in testing, the
problem has gone away. in all cases, this commit should
not break anything, so i would favor merging it