### PR TITLE
Server: configurable log index watermark for snapshotting

### DIFF
--- a/Server/StateMachine.h
+++ b/Server/StateMachine.h
@@ -298,6 +298,13 @@ class StateMachine {
     std::chrono::nanoseconds snapshotWatchdogInterval;
 
     /**
+     * Allowed difference between the latest index of the log and the
+     * index of latest snapshot. If the value is 0 (default), it will be
+     * ignored.
+     */
+    uint64_t snapshotIndexDiff;
+
+    /**
      * The time interval after which to remove an inactive client session, in
      * nanoseconds of cluster time.
      */


### PR DESCRIPTION
This commit adds a new option snapshotIndexWatermark to logcabin
server. The option expresses a ratio of allowed difference between the
latest index of the log and the index of latest snapshot. Current
implementation uses the fixed value (75%).

This commit also fixes a bug in the condition. IIUC, the original
condition of the last branch in StateMachine::shouldTakeSnapshot()
would be always true.